### PR TITLE
Don't show file in both "winning" and "losing"

### DIFF
--- a/red4-conflicts/src/lib.rs
+++ b/red4-conflicts/src/lib.rs
@@ -151,8 +151,13 @@ impl TemplateApp {
                         // update vms
                         // add this file to all previous archive's losing files
                         for archive in archive_names.iter() {
-                            if !self.archives.get(archive).unwrap().loses.contains(hash) {
-                                self.archives.get_mut(archive).unwrap().loses.push(*hash);
+                            let archive_vm = self.archives.get_mut(archive).unwrap();
+                            if !archive_vm.loses.contains(hash) {
+                                archive_vm.loses.push(*hash);
+                            }
+                            // remove from wins if previously marked as winning
+                            if let Some(pos) = archive_vm.wins.iter().position(|w| w == hash) {
+                                archive_vm.wins.remove(pos);
                             }
                         }
                         // add the current archive to the list of conflicting archives last


### PR DESCRIPTION
<img width="539" height="208" alt="image" src="https://github.com/user-attachments/assets/3595a360-22b2-41c4-94cd-439c7d3c06af" />

This happens when 3 archives (or more) edits the same file. The "middle" archive would both win over an lower prio, and lose against a higher prio. 
 
This could be confusing, and especially when an archive has all their files "beaten" by another, as they would _not_ be marked as obsolete.

This PR changes the behaviour to only show "winning" if no other archive wins that file. Each file is only in a single "winning" list.

<img width="532" height="156" alt="image" src="https://github.com/user-attachments/assets/c4396115-ccb2-470c-a08e-4f839c424d6e" />


I undestand the original behaviour is maybe intended, but I think highlighting only files that are actually "winning" would be clearer to users.